### PR TITLE
Fix Static Flea Ban List

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -636,7 +636,7 @@ class ItemInfo implements IPostDBLoadMod {
 				// let RarityPvE = item._props.RarityPvE
 				// log(`${this.getItemName(itemID)} | ${RarityPvE}`)
 				let isBanned = false
-				if (config.useBSGStaticFleaBanlist) {
+				if (config.useBSGStaticFleaBanlist.enabled) {
 					isBanned = bsgBlacklist.includes(itemID)
 				} else {
 					isBanned = !item._props.CanSellOnRagfair


### PR DESCRIPTION
Opened PR on DrakiaXYZ's fork here [#1](https://github.com/DrakiaXYZ/SPT-ODT-ItemInfo/pull/1) however seeing as this is the most up to date version on the hub I will open this here as well.

Currently we aren't even checking the correct key in the config so it has no effect. This resolves "BANNED" still showing when disabling the static flea ban list with a blacklist remover also enabled